### PR TITLE
Implement a Log4J2 ContextDataProvider

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -37,7 +37,7 @@ To transport distributed traces information, a new `localContext` data map is at
 This library:
 
 * uses the `localContext` data map to store contextual data
-* implements logging converters that retrieve contextual data from the `localContext` data map
+* implements logging extensions that retrieve contextual data from the `localContext` data map
 
 == Dependency setup
 
@@ -124,7 +124,15 @@ Below is a sample Logback configuration:
 
 ==== Log4j2
 
-With Log4j2, the converter is configured automatically.
+With Log4j2, you can either use:
+
+* the xref:log4j2_pattern_converter[pattern converter], or
+* the xref:log4j2_context_data_provider[context data provider].
+
+[#log4j2_pattern_converter]
+===== Pattern Converter
+
+The Log4j2 pattern converter is configured automatically.
 It works like the Logback converter, except the conversion word is fixed to `vcl`.
 
 Below is a sample Log4j2 configuration:
@@ -146,6 +154,30 @@ Below is a sample Log4j2 configuration:
   </Loggers>
 </Configuration>
 ----
+
+[#log4j2_context_data_provider]
+===== Context Data Provider
+
+The context data provider supplies log4j2 logging events with contextual data.
+The data can then be retrieved using https://logging.apache.org/log4j/2.x/manual/lookups.html#ContextMapLookup[context map lookups].
+
+To enable the provider, create a `META-INF/services/org.apache.logging.log4j.core.util.ContextDataProvider` file which this content:
+
+----
+io.reactiverse.contextual.logging.VertxContextDataProvider
+----
+
+===== Comparison
+
+The pattern converter:
+
+* can only be used in https://logging.apache.org/log4j/2.x/manual/layouts.html#PatternLayout[pattern layouts]
+* is only invoked if the appender actually writes event data to the destination
+
+The context data provider:
+
+* can be used anywhere log4j2 supports https://logging.apache.org/log4j/2.x/manual/lookups.html#ContextMapLookup[context map lookups] (e.g. https://logging.apache.org/log4j/2.x/manual/layouts.html#JSONLayout[JSON layout])
+* is invoked anytime log4j creates a logging event
 
 ==== JUL
 

--- a/src/main/java/io/reactiverse/contextual/logging/VertxContextDataProvider.java
+++ b/src/main/java/io/reactiverse/contextual/logging/VertxContextDataProvider.java
@@ -1,0 +1,42 @@
+
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.reactiverse.contextual.logging;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.ContextInternal;
+import org.apache.logging.log4j.core.util.ContextDataProvider;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static io.reactiverse.contextual.logging.ContextualData.contextualDataMap;
+
+/**
+ * Supplies log4j2 log events with Vert.x Contextual Data.
+ */
+public class VertxContextDataProvider implements ContextDataProvider {
+
+  @Override
+  public Map<String, String> supplyContextData() {
+    ContextInternal ctx = (ContextInternal) Vertx.currentContext();
+    if (ctx != null) {
+      return Collections.unmodifiableMap(contextualDataMap(ctx));
+    }
+    return Collections.emptyMap();
+  }
+}

--- a/src/test/java/io/reactiverse/contextual/logging/ContextualLoggingTest.java
+++ b/src/test/java/io/reactiverse/contextual/logging/ContextualLoggingTest.java
@@ -39,19 +39,24 @@ import static java.util.stream.Collectors.*;
 public class ContextualLoggingTest extends VertxTestBase {
 
   private static final String REQUEST_ID_HEADER = "x-request-id";
-  private static final String LOGGING_PATTERN = "%vcl{requestId:-foobar} ### %msg%n";
 
   private TestLogger log;
 
   @Test
   public void testLogback() {
-    log = new LogbackTestLogger(LOGGING_PATTERN);
+    log = new LogbackTestLogger("%vcl{requestId:-foobar} ### %msg%n");
     testContextualLogging(log);
   }
 
   @Test
-  public void testLog4j2() {
-    log = new Log4j2TestLogger(LOGGING_PATTERN);
+  public void testLog4j2Converter() {
+    log = new Log4j2TestLogger("%vcl{requestId:-foobar} ### %msg%n");
+    testContextualLogging(log);
+  }
+
+  @Test
+  public void testLog4j2ContextMapLookup() {
+    log = new Log4j2TestLogger("${ctx:requestId:-foobar} ### %msg%n");
     testContextualLogging(log);
   }
 

--- a/src/test/resources/META-INF/services/org.apache.logging.log4j.core.util.ContextDataProvider
+++ b/src/test/resources/META-INF/services/org.apache.logging.log4j.core.util.ContextDataProvider
@@ -1,0 +1,17 @@
+#
+# Copyright 2021 Red Hat, Inc.
+#
+# Red Hat licenses this file to you under the Apache License, version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at:
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+io.reactiverse.contextual.logging.VertxContextDataProvider


### PR DESCRIPTION
Closes #4

VertxContextDataProvider supplies logging events with contextual data.

The advantage is that data can then be retrieved anywhere log4j2 supports context map lookups.
The drawback is the provider is invoked anytime a logging event is created (an event is not created if the log level is below the configured threshold).