### PR TITLE
Vertx 5 ugrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        jdk: [8,11,17]
+        jdk: [ 11,17,21 ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -40,7 +40,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: 11
           server-id: ossrh
           server-username: SONATYPE_NEXUS_USERNAME
           server-password: SONATYPE_NEXUS_PASSWORD
@@ -64,7 +64,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: 11
           server-id: ossrh
           server-username: SONATYPE_NEXUS_USERNAME
           server-password: SONATYPE_NEXUS_PASSWORD

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vertx.version>5.0.0-SNAPSHOT</vertx.version>
+    <vertx.version>5.0.0.CR1</vertx.version>
     <logback.version>1.4.14</logback.version>
     <log4j2.version>2.24.2</log4j2.version>
     <slf4j.version>2.0.0</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>io.reactiverse</groupId>
@@ -310,5 +311,19 @@
       <url>https://github.com/tsegismont</url>
     </developer>
   </developers>
+
+  <repositories>
+    <repository>
+      <id>vertx-snapshots-repository</id>
+      <name>Vert.x Snapshots Repository</name>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -27,10 +27,8 @@
   <url>https://github.com/reactiverse/reactiverse-contextual-logging</url>
 
   <properties>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <vertx.version>4.5.1</vertx.version>
+    <vertx.version>5.0.0-SNAPSHOT</vertx.version>
     <logback.version>1.3.0</logback.version>
     <log4j2.version>2.24.2</log4j2.version>
     <slf4j.version>2.0.0</slf4j.version>
@@ -91,6 +89,14 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.12.1</version>
+        <configuration>
+          <release>11</release>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.asciidoctor</groupId>
         <artifactId>asciidoctor-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <vertx.version>5.0.0-SNAPSHOT</vertx.version>
-    <logback.version>1.3.0</logback.version>
+    <logback.version>1.4.14</logback.version>
     <log4j2.version>2.24.2</log4j2.version>
     <slf4j.version>2.0.0</slf4j.version>
     <doc.outputDirectory>${project.build.directory}/generated-docs</doc.outputDirectory>

--- a/src/main/java/io/reactiverse/contextual/logging/JULContextualDataFormatter.java
+++ b/src/main/java/io/reactiverse/contextual/logging/JULContextualDataFormatter.java
@@ -15,7 +15,7 @@
  */
 package io.reactiverse.contextual.logging;
 
-import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.internal.ContextInternal;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -32,7 +32,7 @@ import java.util.logging.LogRecord;
  * JUL Formatted that is able to process Vert.x Context data. Besides the format used in the parent class,
  * vert.x context variables can be referred by name too. For simplicity the default variables are also exposed
  * by name and cannot be overridden.
- *
+ * <p>
  * {@inheritDoc}
  * @author Paulo Lopes
  */

--- a/src/main/java/io/reactiverse/contextual/logging/Log4j2Converter.java
+++ b/src/main/java/io/reactiverse/contextual/logging/Log4j2Converter.java
@@ -16,7 +16,7 @@
 
 package io.reactiverse.contextual.logging;
 
-import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.internal.ContextInternal;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.pattern.ConverterKeys;

--- a/src/main/java/io/reactiverse/contextual/logging/LogbackConverter.java
+++ b/src/main/java/io/reactiverse/contextual/logging/LogbackConverter.java
@@ -18,7 +18,7 @@ package io.reactiverse.contextual.logging;
 
 import ch.qos.logback.classic.pattern.ClassicConverter;
 import ch.qos.logback.classic.spi.ILoggingEvent;
-import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.internal.ContextInternal;
 
 import static ch.qos.logback.core.util.OptionHelper.extractDefaultReplacement;
 

--- a/src/main/java/io/reactiverse/contextual/logging/impl/ContextualDataImpl.java
+++ b/src/main/java/io/reactiverse/contextual/logging/impl/ContextualDataImpl.java
@@ -16,9 +16,9 @@
 
 package io.reactiverse.contextual.logging.impl;
 
-import io.vertx.core.impl.ContextInternal;
-import io.vertx.core.impl.logging.Logger;
-import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.logging.Logger;
+import io.vertx.core.internal.logging.LoggerFactory;
 
 import java.util.Collections;
 import java.util.HashMap;

--- a/src/main/java/io/reactiverse/contextual/logging/impl/ContextualDataImpl.java
+++ b/src/main/java/io/reactiverse/contextual/logging/impl/ContextualDataImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc.
+ * Copyright 2024 Red Hat, Inc.
  *
  * Red Hat licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -26,6 +26,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+
+import static io.reactiverse.contextual.logging.impl.ContextualDataStorage.CONTEXTUAL_DATA_KEY;
+import static io.vertx.core.spi.context.storage.AccessMode.CONCURRENT;
 
 public class ContextualDataImpl {
 
@@ -94,9 +97,9 @@ public class ContextualDataImpl {
     return null;
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "rawtypes"})
   private static ConcurrentMap<String, String> contextualDataMap(ContextInternal ctx) {
-    ConcurrentMap<Object, Object> lcd = Objects.requireNonNull(ctx).localContextData();
-    return (ConcurrentMap<String, String>) lcd.computeIfAbsent(ContextualDataImpl.class, k -> new ConcurrentHashMap<>());
+    ConcurrentMap lcd = Objects.requireNonNull(ctx).getLocal(CONTEXTUAL_DATA_KEY, CONCURRENT, ConcurrentHashMap::new);
+    return (ConcurrentMap<String, String>) lcd;
   }
 }

--- a/src/main/java/io/reactiverse/contextual/logging/impl/ContextualDataStorage.java
+++ b/src/main/java/io/reactiverse/contextual/logging/impl/ContextualDataStorage.java
@@ -16,7 +16,7 @@
 
 package io.reactiverse.contextual.logging.impl;
 
-import io.vertx.core.impl.VertxBuilder;
+import io.vertx.core.internal.VertxBootstrap;
 import io.vertx.core.spi.VertxServiceProvider;
 import io.vertx.core.spi.context.storage.ContextLocal;
 
@@ -31,6 +31,6 @@ public class ContextualDataStorage implements VertxServiceProvider {
   static ContextLocal<ConcurrentMap> CONTEXTUAL_DATA_KEY = ContextLocal.registerLocal(ConcurrentMap.class);
 
   @Override
-  public void init(VertxBuilder builder) {
+  public void init(VertxBootstrap builder) {
   }
 }

--- a/src/main/java/io/reactiverse/contextual/logging/impl/ContextualDataStorage.java
+++ b/src/main/java/io/reactiverse/contextual/logging/impl/ContextualDataStorage.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.reactiverse.contextual.logging.impl;
+
+import io.vertx.core.impl.VertxBuilder;
+import io.vertx.core.spi.VertxServiceProvider;
+import io.vertx.core.spi.context.storage.ContextLocal;
+
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * SPI Implementation for {@link ContextLocal} storage.
+ */
+public class ContextualDataStorage implements VertxServiceProvider {
+
+  @SuppressWarnings("rawtypes")
+  static ContextLocal<ConcurrentMap> CONTEXTUAL_DATA_KEY = ContextLocal.registerLocal(ConcurrentMap.class);
+
+  @Override
+  public void init(VertxBuilder builder) {
+  }
+}

--- a/src/main/resources/META-INF/services/io.vertx.core.spi.VertxServiceProvider
+++ b/src/main/resources/META-INF/services/io.vertx.core.spi.VertxServiceProvider
@@ -1,0 +1,17 @@
+#
+# Copyright 2024 Red Hat, Inc.
+#
+# Red Hat licenses this file to you under the Apache License, version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at:
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+io.reactiverse.contextual.logging.impl.ContextualDataStorage

--- a/src/test/java/io/reactiverse/contextual/logging/ContextualLoggingIT.java
+++ b/src/test/java/io/reactiverse/contextual/logging/ContextualLoggingIT.java
@@ -17,13 +17,13 @@
 package io.reactiverse.contextual.logging;
 
 import io.vertx.core.*;
+import io.vertx.core.http.HttpResponseExpectation;
 import io.vertx.core.http.HttpServer;
-import io.vertx.core.impl.logging.Logger;
-import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.core.internal.logging.Logger;
+import io.vertx.core.internal.logging.LoggerFactory;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
-import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import io.vertx.ext.web.codec.BodyCodec;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;
@@ -93,8 +93,9 @@ public class ContextualLoggingIT extends VertxTestBase {
     List<Future<?>> futures = ids.stream()
       .map(id -> webClient
         .get("/")
-        .expect(ResponsePredicate.SC_OK)
-        .putHeader(REQUEST_ID_HEADER, id).send())
+        .putHeader(REQUEST_ID_HEADER, id)
+        .send()
+        .expecting(HttpResponseExpectation.SC_OK))
       .collect(toList());
     Future.all(futures).<Void>mapEmpty().onComplete(handler);
   }

--- a/src/test/java/io/reactiverse/contextual/logging/ContextualLoggingIT.java
+++ b/src/test/java/io/reactiverse/contextual/logging/ContextualLoggingIT.java
@@ -75,7 +75,7 @@ public class ContextualLoggingIT extends VertxTestBase {
 
   @Test
   public void testContextualLogging() {
-    vertx.deployVerticle(new TestVerticle(), onSuccess(id -> {
+    vertx.deployVerticle(new TestVerticle()).onComplete(onSuccess(id -> {
       List<String> ids = IntStream.range(0, 10).mapToObj(i -> UUID.randomUUID().toString()).collect(toList());
       sendRequests(ids, onSuccess(v -> {
         try {
@@ -147,9 +147,9 @@ public class ContextualLoggingIT extends VertxTestBase {
               log.info("Blocking task executed ### " + requestId);
               return null;
 
-            }, false, bar -> {
+            }, false).onComplete(bar -> {
 
-              request.send(rar -> {
+              request.send().onComplete(rar -> {
 
                 log.info("Received Web Client response ### " + requestId);
                 req.response().end();
@@ -159,7 +159,7 @@ public class ContextualLoggingIT extends VertxTestBase {
             });
           });
 
-        }).listen(8080, lar -> {
+        }).listen(8080).onComplete(lar -> {
 
           if (lar.succeeded()) {
             log.info("Started!");


### PR DESCRIPTION
Prepare for Vert.x 5 release

- [X] Vert.x 5 upgrade
- [X] JDK 11 update
- [X] ContextLocal storage for better performances
- [X] Logback update (requires JDK11 as baseline)
