### PR TITLE
Bump org.apache.logging.log4j:log4j-core from 2.24.3 to 2.25.0

### DIFF
--- a/log4j2/pom.xml
+++ b/log4j2/pom.xml
@@ -29,7 +29,7 @@
   <artifactId>reactiverse-contextual-logging-log4j2</artifactId>
 
   <properties>
-    <log4j2.version>2.24.3</log4j2.version>
+    <log4j2.version>2.25.0</log4j2.version>
   </properties>
 
   <dependencies>
@@ -85,6 +85,10 @@
               <version>${log4j2.version}</version>
             </annotationProcessorPath>
           </annotationProcessorPaths>
+          <compilerArgs>
+            <arg>-Alog4j.graalvm.groupId=${project.groupId}</arg>
+            <arg>-Alog4j.graalvm.artifactId=${project.artifactId}</arg>
+          </compilerArgs>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
 Added the required compiler args

 See https://logging.apache.org/log4j/2.x/release-notes.html#release-notes-2-25-0